### PR TITLE
Update Main.cs

### DIFF
--- a/ClustertruckSplit/Main.cs
+++ b/ClustertruckSplit/Main.cs
@@ -77,7 +77,7 @@ namespace ClustertruckSplit
 
 
             // TODO: Fix bug with dying and splitting...
-            if ((info.playing && !OldPlaying) && (info.currentLevel == 1))
+            if ((info.playing && !OldPlaying) && (info.currentLevel % 10 == 1))
             {
 
                 if (Variables.CurrentPlayer != null)


### PR DESCRIPTION
Doing (info.currentLevel % 10 == 1) should allow people to start the timer on any first level of any world. This is extremely helpful for doing individual worlds for speedrunning.